### PR TITLE
Extended game controller support

### DIFF
--- a/bbruntime/bbinput.h
+++ b/bbruntime/bbinput.h
@@ -36,6 +36,8 @@ int		 bbJoyDown(int n, int port);
 int		 bbJoyHit(int n, int port);
 int		 bbGetJoy(int port);
 int		 bbWaitJoy(int port);
+int		 bbJoyCount();
+int		 bbJoyConnected(int port);
 float	 bbJoyX(int port);
 float	 bbJoyY(int port);
 float	 bbJoyZ(int port);
@@ -47,8 +49,12 @@ float	 bbJoyRoll(int port);
 int		 bbJoyXDir(int port);
 int		 bbJoyYDir(int port);
 int		 bbJoyZDir(int port);
+float	 bbJoyLeftTrigger(int port);
+float	 bbJoyRightTrigger(int port);
 int		 bbJoyUDir(int port);
 int		 bbJoyVDir(int port);
+void	 bbJoyVibrate(int port, float left, float right);
+void	 bbStopJoyVibrate(int port);
 void	 bbFlushJoy();
 
 #endif

--- a/gxruntime/gxinput.h
+++ b/gxruntime/gxinput.h
@@ -4,11 +4,22 @@
 #define DIRECTINPUT_VERSION 0x0800
 
 #include <dinput.h>
+#include <xinput.h>
 
 #include "gxdevice.h"
 #include <vector>
 
 class gxRuntime;
+
+class XInputController : public gxDevice {
+public:
+	int index;
+	XINPUT_STATE state;
+	XINPUT_STATE prev_state;
+
+	XInputController(int index);
+	void update();
+};
 
 class gxInput {
 public:
@@ -40,12 +51,15 @@ public:
 		ASC_UP = 28, ASC_DOWN = 29, ASC_RIGHT = 30, ASC_LEFT = 31
 	};
 
+	std::vector<XInputController*> xinput_controllers;
+
 	void moveMouse(int x, int y);
 
 	gxDevice* getMouse()const;
 	gxDevice* getKeyboard()const;
 	gxDevice* getJoystick(int port)const;
 	std::vector<int> getChars();
+	bool getControllerConnected(int port);
 	int getJoystickType(int port)const;
 	int numJoysticks()const;
 	int toAscii(int key)const;


### PR DESCRIPTION
Added XInput library to extend existing support for game controller. Added additional blitzbasic functions to check for controller connectivity and count and compatibility.

Here's my code which I used to test for these new changes (so at least no-one has to reinvent the wheel, so to speak):
```blitz3d
Graphics3D 800,600,32,2
SetBuffer BackBuffer()

Global vibTime = 0

While Not KeyDown(1)
    Cls
    UpdateInput() 
    currentConnectedCount = 0
    yPos = 10
    For j = 0 To 15 ; Shouldn't more than this meany ports at least :P
        If JoyConnected(j)
            currentConnectedCount = currentConnectedCount + 1
            Text 10, yPos, "Controller "+j+" (Type: "+JoyType(j)+") - Connected: True"
            yPos = yPos + 20
            
            ; Game Controller Analog Axis Testing - (Xbox One Controller Testing for Thumbsticks)
            Text 10, yPos, "Analog Inputs:"
            Text 250, yPos, "LX="+JoyX(j)
            Text 350, yPos, "LY="+JoyY(j)
            yPos = yPos + 20
            Text 250, yPos, "RX="+JoyU(j)
            Text 350, yPos, "RY="+JoyV(j)
            yPos = yPos + 30
            
            ; Game Controller Trigger's Testing - (Xbox One Controller Testing for Triggers)
            Text 10, yPos, "Triggers:"
            Text 250, yPos, "LT="+JoyLeftTrigger(j)
            Text 350, yPos, "RT="+JoyRightTrigger(j)
            Text 450, yPos, "Combined Triggers (Trigger Differential)="+JoyZ(j)
            yPos = yPos + 30
            
            ; Game Controller Button Press Testing - (Xbox One Controller Testing for general Button mashing)
            btnText$ = "Buttons Pressed: "
            If JoyDown(0,j) Then btnText$ = btnText + "D-Up "   ; D-PAD Up
            If JoyDown(1,j) Then btnText$ = btnText + "D-Down " ; D-PAD Down
            If JoyDown(2,j) Then btnText$ = btnText + "D-Left " ; D-PAD Left
            If JoyDown(3,j) Then btnText$ = btnText + "D-Right "; D-PAD Right
            If JoyDown(4,j) Then btnText$ = btnText + "Start "  ; Start
            If JoyDown(5,j) Then btnText$ = btnText + "Back "   ; Back
            If JoyDown(6,j) Then btnText$ = btnText + "L3 "     ; Left Stick Click
            If JoyDown(7,j) Then btnText$ = btnText + "R3 "     ; Right Stick Click
            If JoyDown(8,j) Then btnText$ = btnText + "LB "     ; Left Bumper
            If JoyDown(9,j) Then btnText$ = btnText + "RB "    ; Right Bumper
            If JoyDown(12,j) Then btnText$ = btnText + "A "     ; A
            If JoyDown(13,j) Then btnText$ = btnText + "B "     ; B
            If JoyDown(14,j) Then btnText$ = btnText + "X "     ; X
            If JoyDown(15,j) Then btnText$ = btnText + "Y "     ; Y
            Text 10, yPos, btnText$
            yPos = yPos + 20
            
            ; Game Controller D-PAD/POV Hat Testing - (Xbox One Controller Testing for D-Pad triggers)
            pov = JoyHat(j)
            povDir$ = "Centered"
            Select pov
                Case 0: povDir$ = "Up"
                Case 45: povDir$ = "Up-Right"
                Case 90: povDir$ = "Right"
                Case 135: povDir$ = "Down-Right"
                Case 180: povDir$ = "Down"
                Case 225: povDir$ = "Down-Left"
                Case 270: povDir$ = "Left"
                Case 315: povDir$ = "Up-Left"
            End Select
            Text 10, yPos, "D-PAD State: "+povDir$
            yPos = yPos + 50

            ; Logging button actions with their button ID
            For btn = 0 To 15
                If JoyDown(btn, j) Then
                    buttonName$ = GetButtonName(btn)
                    Text 10, yPos, "Controller " + j + " Button " + buttonName$ + " (" + btn + ")" + " pressed!"
                    yPos = yPos + 20
                EndIf
            Next
            
            ; For XInput-specific feature(s) that DInput8 wouldn't be able to support
            If JoyType(j) = 3 ; XInput Game Controllers online
                ; Game Controller Vibration Testing - (Xbox One Controller Testing for timed Vibration trigger)
                If JoyHit(12,j) ; For use, press of the A Button will trigger timed vibration test
                    vibTime = MilliSecs() + 500
                    JoyVibrate j, 1.0, 1.0
                EndIf
                yPos = yPos + 20
            EndIf
        EndIf
    Next
    
    ; We only show the "no controllers" message if controller is not detected/disconnected
    If currentConnectedCount = 0
        Text 10, yPos, "No controllers detected!"
        yPos = 130 + 20
    EndIf
    
    Flip
Wend

End

Function UpdateInput()
    If MilliSecs() > vibTime And vibTime <> 0
        For j = 0 To 15
            If JoyConnected(j) Then StopJoyVibrate(j)
        Next
        vibTime = 0
    EndIf
End Function

Function GetButtonName$(buttonID)
    Select buttonID
        Case 0: Return "D-Up"
        Case 1: Return "D-Down"
        Case 2: Return "D-Left"
        Case 3: Return "D-Right"
        Case 4: Return "Start"
        Case 5: Return "Back"
        Case 6: Return "L3"
        Case 7: Return "R3"
        Case 8: Return "LB"
        Case 9: Return "RB"
        Case 12: Return "A"
        Case 13: Return "B"
        Case 14: Return "X"
        Case 15: Return "Y"
        Default: Return "Unknown"
    End Select
End Function
```