### PR TITLE
fix: Make XInput compatible with Windows 7

### DIFF
--- a/bbruntime/bbinput.cpp
+++ b/bbruntime/bbinput.cpp
@@ -279,10 +279,12 @@ int	bbJoyVDir(int port) {
 void bbJoyVibrate(int port, float left, float right) {
 	if (port < 0 || port >= gx_joysticks.size()) return;
 	if (gx_input->getJoystickType(port) == 3) {
-		XINPUT_VIBRATION vibration;
-		vibration.wLeftMotorSpeed = static_cast<WORD>(left * 65535);
-		vibration.wRightMotorSpeed = static_cast<WORD>(right * 65535);
-		XInputSetState(port, &vibration);
+		if (XInputSetStateFunc) {
+			XINPUT_VIBRATION vibration;
+			vibration.wLeftMotorSpeed = static_cast<WORD>(left * 65535);
+			vibration.wRightMotorSpeed = static_cast<WORD>(right * 65535);
+			XInputSetStateFunc(port, &vibration);
+		}
 	}
 }
 

--- a/gxruntime/gxinput.h
+++ b/gxruntime/gxinput.h
@@ -9,6 +9,13 @@
 #include "gxdevice.h"
 #include <vector>
 
+// Messy order, messy problem;
+typedef DWORD(WINAPI* XInputGetStatePtr)(DWORD, XINPUT_STATE*);
+typedef DWORD(WINAPI* XInputSetStatePtr)(DWORD, XINPUT_VIBRATION*);
+extern XInputGetStatePtr XInputGetStateFunc;
+extern XInputSetStatePtr XInputSetStateFunc;
+extern HMODULE xinputLibrary;
+
 class gxRuntime;
 
 class XInputController : public gxDevice {


### PR DESCRIPTION
The Windows 7 environment was unable to run due to differentiating XInput versions that could be supported. This specific version of XInput that was causing problems was XInput1_4.dll, and changes were made to fix that.